### PR TITLE
Mod message bucket, connection management and isUserModerator() slimmed

### DIFF
--- a/src/main/java/me/philippheuer/twitch4j/TwitchClient.java
+++ b/src/main/java/me/philippheuer/twitch4j/TwitchClient.java
@@ -212,6 +212,22 @@ public class TwitchClient {
 	}
 
 	/**
+	 * Connect to other related services.
+	 * <p>
+	 * This methods opens the connection to the twitch irc server and the pubsub endpoint.
+	 * Connect needs to be called after initalizing the {@link CredentialManager}.
+	 */
+	public void disconnect() {
+		getIrcClient().disconnect();
+		getPubSub().disconnect();
+	}
+
+	public void reconnect() {
+		disconnect();
+		connect();
+	}
+
+	/**
 	 * Returns an a new KrakenEndpoint instance.
 	 * <p>
 	 * The Kraken Endpoint is the root of the twitch api.

--- a/src/main/java/me/philippheuer/twitch4j/chat/IrcClient.java
+++ b/src/main/java/me/philippheuer/twitch4j/chat/IrcClient.java
@@ -62,7 +62,7 @@ public class IrcClient {
 		connect();
 	}
 
-	private Boolean connect() {
+	private boolean connect() {
 		Logger.info(this, "Connecting to Twitch IRC [%s]", getTwitchClient().getTwitchIrcEndpoint());
 
 		// Shutdown, if the client is still running
@@ -115,7 +115,7 @@ public class IrcClient {
 		connect();
 	}
 
-	private void disconnect() {
+	public void disconnect() {
 		Logger.info(this, "Disconnecting from Twitch IRC!");
 		getIrcClient().shutdown();
 	}
@@ -147,6 +147,30 @@ public class IrcClient {
 						.build();
 				modMessageBucket.put(channelName, modBucket);
 			}
+		}
+	}
+
+	/**
+	 * Leaving a channel, required to listen for messages
+	 * @param channelName The channel to join.
+	 */
+	public void partChannel(String channelName) {
+		if(getIrcClient() == null) {
+			Logger.warn(this, "IRC Client not initialized. Can't join [%s]!", channelName);
+		}
+
+		String ircChannel = String.format("#%s", channelName);
+		if(getIrcClient().getChannels().contains(ircChannel)) {
+			getIrcClient().removeChannel(ircChannel);
+
+			Logger.info(this, "Leaving Channel [%s]!", channelName);
+
+			// Trigger JoinEvent
+			ChannelJoinEvent event = new ChannelJoinEvent(this.getTwitchClient().getChannelEndpoint(channelName).getChannel());
+			getTwitchClient().getDispatcher().dispatch(event);
+
+			// dropping moderations
+			if (modMessageBucket.containsKey(channelName)) modMessageBucket.remove(channelName);
 		}
 	}
 

--- a/src/main/java/me/philippheuer/twitch4j/chat/IrcClient.java
+++ b/src/main/java/me/philippheuer/twitch4j/chat/IrcClient.java
@@ -3,6 +3,7 @@ package me.philippheuer.twitch4j.chat;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -10,9 +11,11 @@ import java.util.function.Consumer;
 
 import com.jcabi.log.Logger;
 import me.philippheuer.twitch4j.auth.model.OAuthCredential;
+import me.philippheuer.twitch4j.endpoints.TMIEndpoint;
 import me.philippheuer.twitch4j.enums.TwitchScopes;
 import me.philippheuer.twitch4j.events.event.ChannelJoinEvent;
 import me.philippheuer.twitch4j.model.Channel;
+import me.philippheuer.twitch4j.model.User;
 import org.isomorphism.util.TokenBucket;
 import org.isomorphism.util.TokenBuckets;
 import org.kitteh.irc.client.library.Client;
@@ -43,6 +46,8 @@ public class IrcClient {
 			.withCapacity(20)
 			.withFixedIntervalRefillStrategy(1, 1500, TimeUnit.MILLISECONDS)
 			.build();
+	// Token bucket for moderated channels by bot
+	private final Map<String, TokenBucket> modMessageBucket = new HashMap<String, TokenBucket>();
 
 	/**
 	 * Class Constructor
@@ -133,6 +138,15 @@ public class IrcClient {
 			// Trigger JoinEvent
 			ChannelJoinEvent event = new ChannelJoinEvent(this.getTwitchClient().getChannelEndpoint(channelName).getChannel());
 			getTwitchClient().getDispatcher().dispatch(event);
+
+			// Checking user if it is moderator
+			if (getTwitchClient().getTMIEndpoint().getChatters(channelName).getModerators().contains(getIrcClient().getName())){
+				TokenBucket modBucket = TokenBuckets.builder()
+						.withCapacity(100)
+						.withFixedIntervalRefillStrategy(1, 300, TimeUnit.MILLISECONDS)
+						.build();
+				modMessageBucket.put(channelName, modBucket);
+			}
 		}
 	}
 
@@ -147,8 +161,12 @@ public class IrcClient {
 
 		new Thread(() -> {
 			// Consume 1 Token (wait's in case the limit has been exceeded)
-			getMessageBucket().consume(1);
-
+			if (getTwitchClient().getTMIEndpoint().getChatters(channelName).getModerators().contains(getIrcClient().getName())) {
+				// Only for channels if bot is moderator
+				getModMessageBucket().get(channelName).consume(1);
+			} else {
+				getMessageBucket().consume(1);
+			}
 			// Send Message
 			getIrcClient().sendMessage("#" + channelName, message);
 

--- a/src/main/java/me/philippheuer/twitch4j/endpoints/TMIEndpoint.java
+++ b/src/main/java/me/philippheuer/twitch4j/endpoints/TMIEndpoint.java
@@ -68,11 +68,6 @@ public class TMIEndpoint extends AbstractTwitchEndpoint {
 	public Boolean isUserModerator(Channel channel, User user) {
 		Chatter chatter = getChatters(channel.getName());
 
-		if (chatter.getModerators().contains(user.getName())) {
-			return true;
-		}
-
-		return false;
+		return chatter.getModerators().contains(user.getName());
 	}
-
 }

--- a/src/main/java/me/philippheuer/twitch4j/pubsub/TwitchPubSub.java
+++ b/src/main/java/me/philippheuer/twitch4j/pubsub/TwitchPubSub.java
@@ -156,7 +156,7 @@ public class TwitchPubSub {
 	}
 
 	private void reconnect() {
-		cancelTasks();
+		disconnect();
 		if (connect()) {
 			scheduleTasks();
 		} else {
@@ -186,8 +186,13 @@ public class TwitchPubSub {
 		}, 7000, 282000);
 	}
 
+	public void disconnect() {
+		getWebSocket().disconnect();
+		cancelTasks();
+	}
+
 	/**
-	 * Purge the current tasks to prepare for a reconnect.
+	 * Disconnect and purge the current tasks to prepare for a reconnect.
 	 */
 	private void cancelTasks() {
 		timer.cancel();


### PR DESCRIPTION
### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Added mod bucket (where limits for moderating chat is 100 per 30 seconds)
* TMIEndpoint#isUserModerator() - returned value is slimmed
* added disconnect() and reconnect() methods, and makes them to public. (Easiest way controlling connection to the Twitch chat for safe disconnect and reconnect.)

### Additional notes
Test units are incomplete. So I test it on Raw project, and looks very well.