### PR TITLE
Builder changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ Just some simple examples, visit the [WIKI](https://github.com/PhilippHeuer/twit
 ### Client Builder (Twitch Standalone)
 ```java
 TwitchClient twitchClient = TwitchClientBuilder.builder()
-	.setClientId("Twitch App Id")
-	.setClientSecret("Twitch App Secret")
-	.setAutoSaveConfiguration(true)
-	.setConfigurationDirectory(new File("config"))
-	.setIrcCredential("ixsxu9123xzmlx798xooa3f91q1e9c") // Get your token at: https://twitchapps.com/tmi/
+	.withClientId("Twitch App Id")
+	.withClientSecret("Twitch App Secret")
+	.withAutoSaveConfiguration(true)
+	.withConfigurationDirectory(new File("config"))
+	.withCredential("ixsxu9123xzmlx798xooa3f91q1e9c") // Get your token at: https://twitchapps.com/tmi/
 	.connect();
 ```
 

--- a/src/integration/java/me/philippheuer/twitch4j/test/TwitchClientIntegrationTest.java
+++ b/src/integration/java/me/philippheuer/twitch4j/test/TwitchClientIntegrationTest.java
@@ -44,8 +44,8 @@ abstract public class TwitchClientIntegrationTest extends TestCase {
 		// Initalize the Client a single time
 		if(twitchClient == null) {
 			twitchClient = TwitchClientBuilder.init()
-					.setClientId("jzkbprff40iqj646a697cyrvl0zt2m6")
-					.setClientSecret("**SECRET**")
+					.withClientId("jzkbprff40iqj646a697cyrvl0zt2m6")
+					.withSecret("**SECRET**")
 					.build();
 		}
 	}

--- a/src/main/java/me/philippheuer/twitch4j/TwitchClientBuilder.java
+++ b/src/main/java/me/philippheuer/twitch4j/TwitchClientBuilder.java
@@ -31,7 +31,7 @@ public class TwitchClientBuilder {
 	/**
 	 * Client Secret
 	 */
-	private String secret;
+	private String clientSecret;
 
 	/**
 	 * IRC Credential
@@ -74,9 +74,9 @@ public class TwitchClientBuilder {
 	public TwitchClient build() {
 		// Reqired Parameters
 		Assert.notNull(clientId, "You need to provide a client id!");
-		Assert.notNull(secret, "You need to provide a client secret!");
+		Assert.notNull(clientSecret, "You need to provide a client secret!");
 
-		final TwitchClient client = new TwitchClient(clientId, secret);
+		final TwitchClient client = new TwitchClient(clientId, clientSecret);
 		client.getCredentialManager().provideTwitchClient(client);
 		client.getCredentialManager().setSaveCredentials(autoSaveConfiguration);
 		if (configurationDirectory != null) {
@@ -107,7 +107,7 @@ public class TwitchClientBuilder {
 		return client;
 	}
 
-	public TwitchClientBuilder addListener(Object listener) {
+	public TwitchClientBuilder withListener(Object listener) {
 		listeners.add(listener);
 		return this;
 	}
@@ -117,7 +117,7 @@ public class TwitchClientBuilder {
 	 * @return {@link TwitchClient} initialized class
 	 */
 	public TwitchClient connect() {
-		Assert.notNull(credential, "You need provide a OAuth Credentials for Bot. Use: https://twitchapps.com/tmi/ to generate oauth key");
+		Assert.notNull(credential, "You need provide a OAuth Credentials for the Bot. Use: https://twitchapps.com/tmi/ to generate a oauth key.");
 		TwitchClient client = build();
 		client.connect();
 		return client;

--- a/src/main/java/me/philippheuer/twitch4j/TwitchClientBuilder.java
+++ b/src/main/java/me/philippheuer/twitch4j/TwitchClientBuilder.java
@@ -1,6 +1,6 @@
 package me.philippheuer.twitch4j;
 
-import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import me.philippheuer.twitch4j.auth.CredentialManager;
@@ -15,7 +15,8 @@ import java.io.File;
  * @author Damian Staszewski
  */
 @Setter
-@Accessors(chain = true)
+@NoArgsConstructor
+@Accessors(chain = true, prefix = "with")
 public class TwitchClientBuilder {
 
 	/**
@@ -26,12 +27,12 @@ public class TwitchClientBuilder {
 	/**
 	 * Client Secret
 	 */
-	private String clientSecret;
+	private String secret;
 
 	/**
 	 * IRC Credential
 	 */
-	private String ircCredential;
+	private String credential;
 
 	/**
 	 * Auto Saving Configuration
@@ -47,7 +48,6 @@ public class TwitchClientBuilder {
 	 * StreamLabs Client
 	 * TODO: Remove
 	 */
-	@Getter
 	private StreamlabsClient streamlabsClient = null;
 
 	/**
@@ -59,23 +59,15 @@ public class TwitchClientBuilder {
 	}
 
 	/**
-	 * Builder
-	 */
-	private TwitchClientBuilder()
-	{
-
-	}
-
-	/**
 	 * Initialize
 	 * @return {@link TwitchClient} initialized class
 	 */
 	public TwitchClient build() {
 		// Reqired Parameters
 		Assert.notNull(clientId, "You need to provide a client id!");
-		Assert.notNull(clientSecret, "You need to provide a client secret!");
+		Assert.notNull(secret, "You need to provide a client secret!");
 
-		final TwitchClient client = new TwitchClient(clientId, clientSecret);
+		final TwitchClient client = new TwitchClient(clientId, secret);
 		client.getCredentialManager().provideTwitchClient(client);
 		client.getCredentialManager().setSaveCredentials(autoSaveConfiguration);
 		if (configurationDirectory != null) {
@@ -88,14 +80,15 @@ public class TwitchClientBuilder {
 			client.getCommandHandler().initializeConfiguration();
 		}
 
-		if (ircCredential != null)
+		if (credential != null)
 		{
-			client.getCredentialManager().addTwitchCredential(CredentialManager.CREDENTIAL_IRC, new OAuthCredential(ircCredential));
+			client.getCredentialManager().addTwitchCredential(CredentialManager.CREDENTIAL_IRC,
+					new OAuthCredential((credential.toLowerCase().startsWith("oauth:")) ? credential.substring(6) : credential));
 		}
 
 		// Streamlabs
-		if(getStreamlabsClient() != null) {
-			client.setStreamLabsClient(getStreamlabsClient());
+		if(streamlabsClient != null) {
+			client.setStreamLabsClient(streamlabsClient);
 			client.getCredentialManager().provideStreamlabsClient(client.getStreamLabsClient());
 		}
 
@@ -107,6 +100,7 @@ public class TwitchClientBuilder {
 	 * @return {@link TwitchClient} initialized class
 	 */
 	public TwitchClient connect() {
+		Assert.notNull(credential, "You need provide a OAuth Credentials for Bot. Use: https://twitchapps.com/tmi/ to generate oauth key");
 		TwitchClient client = build();
 		client.connect();
 		return client;

--- a/src/main/java/me/philippheuer/twitch4j/TwitchClientBuilder.java
+++ b/src/main/java/me/philippheuer/twitch4j/TwitchClientBuilder.java
@@ -1,14 +1,15 @@
 package me.philippheuer.twitch4j;
 
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
+import lombok.*;
+import lombok.experimental.Wither;
 import me.philippheuer.twitch4j.auth.CredentialManager;
 import me.philippheuer.twitch4j.auth.model.OAuthCredential;
 import me.philippheuer.twitch4j.streamlabs.StreamlabsClient;
 import org.springframework.util.Assert;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Builder to get a TwitchClient Instance by provided various options, to provide the user with a lot of customizable options.
@@ -16,9 +17,10 @@ import java.io.File;
  * @version %I%, %G%
  * @since 1.0
  */
-@Setter
-@NoArgsConstructor
-@Accessors(chain = true, prefix = "with")
+@Getter
+@Wither
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TwitchClientBuilder {
 
 	/**
@@ -53,6 +55,11 @@ public class TwitchClientBuilder {
 	private StreamlabsClient streamlabsClient = null;
 
 	/**
+	 * List of listeners
+	 */
+	private final Set<Object> listeners = new HashSet<>();
+
+	/**
 	 * Initializing builder
 	 * @return Client Builder
 	 */
@@ -82,8 +89,7 @@ public class TwitchClientBuilder {
 			client.getCommandHandler().initializeConfiguration();
 		}
 
-		if (credential != null)
-		{
+		if (credential != null) {
 			client.getCredentialManager().addTwitchCredential(CredentialManager.CREDENTIAL_IRC,
 					new OAuthCredential((credential.toLowerCase().startsWith("oauth:")) ? credential.substring(6) : credential));
 		}
@@ -94,7 +100,16 @@ public class TwitchClientBuilder {
 			client.getCredentialManager().provideStreamlabsClient(client.getStreamLabsClient());
 		}
 
+		if (listeners.size() > 0) {
+			listeners.forEach(client.getDispatcher()::registerListener);
+		}
+
 		return client;
+	}
+
+	public TwitchClientBuilder addListener(Object listener) {
+		listeners.add(listener);
+		return this;
 	}
 
 	/**

--- a/src/main/java/me/philippheuer/twitch4j/TwitchClientBuilder.java
+++ b/src/main/java/me/philippheuer/twitch4j/TwitchClientBuilder.java
@@ -12,7 +12,9 @@ import java.io.File;
 
 /**
  * Builder to get a TwitchClient Instance by provided various options, to provide the user with a lot of customizable options.
- * @author Damian Staszewski
+ * @author Damian Staszewski [https://github.com/stachu540]
+ * @version %I%, %G%
+ * @since 1.0
  */
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION

### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
- setters with prefix `with`
- removing getters (when field is private `@Getter` is not needed here)
- Asserting credentials when you are using `connect()` method
- adding method `addListener()` to adding listeners into dispatcher.

### Additional Notes
Setters now have prefix `with`. It will be looks like example under:
```java

clientBulder.withClientId("<clientId>")
	.withSecret("<clientSecret>")
	.withCredentials("<ircCredentials>")
	.build() // or .connect()
```